### PR TITLE
Made Python version parsing be able to process more options

### DIFF
--- a/.github/workflows/pygo-lint-test.yml
+++ b/.github/workflows/pygo-lint-test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Extract Python version from pyproject.toml
-        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?|"$//g')" >> "$GITHUB_ENV"
+        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?>?=?|<?=?|"$//g' | sed -r 's/,/ /' | awk '{print $1}')" >> "$GITHUB_ENV"
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python_version || env.PYTHON_VERSION }}

--- a/.github/workflows/python-library-release.yml
+++ b/.github/workflows/python-library-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Extract Python version from pyproject.toml
-        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?|"$//g')" >> "$GITHUB_ENV"
+        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?>?=?|<?=?|"$//g' | sed -r 's/,/ /' | awk '{print $1}')" >> "$GITHUB_ENV"
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python_version || env.PYTHON_VERSION }}

--- a/.github/workflows/python-lint-test.yml
+++ b/.github/workflows/python-lint-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Extract Python version from pyproject.toml
-        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?|"$//g')" >> "$GITHUB_ENV"
+        run: echo "PYTHON_VERSION=$(grep -E "^python\s?=" < pyproject.toml | awk '{print $3}' | sed -r 's/^"\^?\~?>?=?|<?=?|"$//g' | sed -r 's/,/ /' | awk '{print $1}')" >> "$GITHUB_ENV"
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ inputs.python_version || env.PYTHON_VERSION }}


### PR DESCRIPTION
Now the expression can process entries like:

- `>=3.8,<3.11` => `3.8`
- `<=3.11` => `3.11`
- `>=3.8` => `3.8`

It will still sometimes fail to pick a proper Python version, but the range has been improved