### PR TITLE
apply 'go-upload-s3' job for 'production' branch only

### DIFF
--- a/.github/workflows/go-upload-s3.yml
+++ b/.github/workflows/go-upload-s3.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   go-upload-s3:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/production'
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
Doesn't make sense to upload non-production builds to S3 since they are never used

Ticket: https://trello.com/c/BDsQEXAk/5783-non-production-go-based-services-are-uploaded-to-s3