### PR TITLE
remove production branch restriction 

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -17,7 +17,7 @@ on:
         description: "Git branches eligible to build"
         type: string
         required: false
-        default: 'master production main'
+        default: 'production'
     outputs:
       artifact:
         description: 'Binary output artifact'

--- a/.github/workflows/go-upload-s3.yml
+++ b/.github/workflows/go-upload-s3.yml
@@ -29,7 +29,6 @@ on:
 jobs:
   go-upload-s3:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/production'
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
because branches filtered in build workflow. 