### PR TITLE
Set outputs the new way

### DIFF
--- a/.github/workflows/nomad-pack-plan.yml
+++ b/.github/workflows/nomad-pack-plan.yml
@@ -100,7 +100,7 @@ jobs:
         res="${res//$'\n'/'%0A'}"
         res="${res//$'\r'/'%0D'}"
 
-        echo "stdout=$res" >> $GITHUB_OUTPUT
+        echo "stdout=$res" >> "$GITHUB_OUTPUT"
 
 
     - name: PR Comment

--- a/.github/workflows/nomad-pack-plan.yml
+++ b/.github/workflows/nomad-pack-plan.yml
@@ -100,7 +100,7 @@ jobs:
         res="${res//$'\n'/'%0A'}"
         res="${res//$'\r'/'%0D'}"
 
-        echo "::set-output name=stdout::$res"
+        echo "stdout=$res" >> $GITHUB_OUTPUT
 
 
     - name: PR Comment

--- a/.github/workflows/nomad-plan.yml
+++ b/.github/workflows/nomad-plan.yml
@@ -78,7 +78,7 @@ jobs:
         res="${res//$'\n'/'%0A'}"
         res="${res//$'\r'/'%0D'}"
 
-        echo "stdout=$res" >> $GITHUB_OUTPUT
+        echo "stdout=$res" >> "$GITHUB_OUTPUT"
 
     - name: PR Comment
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/nomad-plan.yml
+++ b/.github/workflows/nomad-plan.yml
@@ -78,7 +78,7 @@ jobs:
         res="${res//$'\n'/'%0A'}"
         res="${res//$'\r'/'%0D'}"
 
-        echo "::set-output name=stdout::$res"
+        echo "stdout=$res" >> $GITHUB_OUTPUT
 
     - name: PR Comment
       if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/python-library-release.yml
+++ b/.github/workflows/python-library-release.yml
@@ -115,7 +115,7 @@ jobs:
           make tag
       - name: Set version output
         id: versionSet
-        run: echo "::set-output name=version::$(make version)"
+        run: echo "version=$(make version)" >> $GITHUB_OUTPUT
 
       - name: Upload the artifact to S3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/python-library-release.yml
+++ b/.github/workflows/python-library-release.yml
@@ -115,7 +115,7 @@ jobs:
           make tag
       - name: Set version output
         id: versionSet
-        run: echo "version=$(make version)" >> $GITHUB_OUTPUT
+        run: echo "version=$(make version)" >> "$GITHUB_OUTPUT"
 
       - name: Upload the artifact to S3
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
Linter complained:
> workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions