### PR TITLE
SRE-329 Improve deploy notifications

### DIFF
--- a/.github/workflows/nomad-pack.yml
+++ b/.github/workflows/nomad-pack.yml
@@ -60,7 +60,6 @@ jobs:
     with:
       cluster: ${{ inputs.cluster }}
       status: running
-      channels: D02U7F64NMP
     secrets:
       slack_bot_token: ${{ secrets.slack_bot_token }}
 
@@ -149,7 +148,6 @@ jobs:
     with:
       cluster: ${{ inputs.cluster }}
       status: ${{ needs.nomad.result }}
-      channels: D02U7F64NMP
       update_ts: ${{ needs.slack-notify-start.outputs.ts }}
     secrets:
       slack_bot_token: ${{ secrets.slack_bot_token }}

--- a/.github/workflows/nomad-pack.yml
+++ b/.github/workflows/nomad-pack.yml
@@ -50,7 +50,20 @@ on:
       ssh_key:
         description: "SSH key to use"
         required: true
+      slack_bot_token:
+        required: true
+        description: "Access token for Slack"
+
 jobs:
+  slack-notify-start:
+    uses: remerge/workflows/.github/workflows/slack-notify.yml@SRE-329-make-slack-deploy-notifications-less-flashy
+    with:
+      cluster: ${{ inputs.cluster }}
+      status: running
+      channels: D02U7F64NMP
+    secrets:
+      slack_bot_token: ${{ secrets.slack_bot_token }}
+
   nomad:
     runs-on: [self-hosted, generic, nomad]
     steps:
@@ -128,3 +141,15 @@ jobs:
           --var='environment=${{ inputs.environment }}' \
           --var-file=${{ inputs.variables_file_name }} \
           --name=${{ inputs.name }} --registry=remerge-pack
+
+  slack-notify-finish:
+    if: ${{ always() && needs.nomad.result != 'skipped' }}
+    needs: [nomad, slack-notify-start]
+    uses: remerge/workflows/.github/workflows/slack-notify.yml@SRE-329-make-slack-deploy-notifications-less-flashy
+    with:
+      cluster: ${{ inputs.cluster }}
+      status: ${{ needs.nomad.result }}
+      channels: D02U7F64NMP
+      update_ts: ${{ needs.slack-notify-start.outputs.ts }}
+    secrets:
+      slack_bot_token: ${{ secrets.slack_bot_token }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -57,7 +57,7 @@ jobs:
             var icon = "";
 
             if (deploy_status == "running") {
-                header += "Deploying ${{ inputs.service_name }}... :crossed_fingers:";
+                header += "${{ inputs.service_name }} deploying... :crossed_fingers:";
                 icon = ":loading-mac:";
             } else if (deploy_status == "success") {
                 header += "${{ inputs.service_name }} deployed successfully :rocket:"

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -61,10 +61,10 @@ jobs:
             var icon = "";
 
             if (deploy_status == "running") {
-                header += "Deploying ${{ inputs.service_name }} to ${{ inputs.service_name }} :crossed_fingers:";
+                header += "Deploying ${{ inputs.service_name }}... :crossed_fingers:";
                 icon = ":loading-mac:";
             } else if (deploy_status == "success") {
-                header += "New ${{ inputs.service_name }} deployed :rocket:"
+                header += "${{ inputs.service_name }} deployed successfully :rocket:"
                 icon = ":white_check_mark:";
             } else {
                 header += "${{ inputs.service_name }} deployment failed :boom:"
@@ -121,7 +121,7 @@ jobs:
                         type: "section",
                         text: {
                             type: "mrkdwn",
-                            text: "*Status*\n" + icon + " " + deploy_status
+                            text: "*Status*
                         }
                     }
                 ]

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -96,7 +96,21 @@ jobs:
                         type: "section",
                         text: {
                             type: "mrkdwn",
-                            text: "${{ github.actor }} pushed <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                            text: "*Revision*\n<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                        }
+                    },
+                    {
+                        type: "section",
+                        text: {
+                            type: "mrkdwn",
+                            text: "*By*\n${{ github.actor }}"
+                        }
+                    },
+                    {
+                        type: "section",
+                        text: {
+                            type: "mrkdwn",
+                            text: "*Status*"
                         }
                     }
                 ]

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -96,7 +96,7 @@ jobs:
                         type: "section",
                         text: {
                             type: "mrkdwn",
-                            text: "*Revision*\n${{ github.sha }}"
+                            text: "*Revision*\n<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
                         }
                     },
                     {

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -74,7 +74,7 @@ jobs:
                             type: "section",
                             text: {
                                 type: "mrkdwn",
-                                text: "<http://nomad.service.${{ inputs.cluster }}.consul:4646/ui/jobs/nomad-sample@default|`${{ inputs.cluster }}`> " + icon
+                                text: "<http://nomad.service.${{ inputs.cluster }}.consul:4646/ui/jobs/${{ github.event.repository.name }}@default|`${{ inputs.cluster }}`> " + icon
                             }
                         }
                     ]

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -96,21 +96,7 @@ jobs:
                         type: "section",
                         text: {
                             type: "mrkdwn",
-                            text: "*Revision*\n<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
-                        }
-                    },
-                    {
-                        type: "section",
-                        text: {
-                            type: "mrkdwn",
-                            text: "*By*\n${{ github.actor }}"
-                        }
-                    },
-                    {
-                        type: "section",
-                        text: {
-                            type: "mrkdwn",
-                            text: "*Status*"
+                            text: "${{ github.actor }} pushed <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
                         }
                     }
                 ]

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -74,7 +74,7 @@ jobs:
                             type: "section",
                             text: {
                                 type: "mrkdwn",
-                                text: "`${{ inputs.cluster }}` " + icon
+                                text: "<http://nomad.service.${{ inputs.cluster }}.consul:4646/ui/jobs/nomad-sample@default|`${{ inputs.cluster }}`> " + icon
                             }
                         }
                     ]

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -5,21 +5,25 @@ on:
     inputs:
       service_name:
         type: string
-        required: true
+        required: false
         description: "Human-readable name of the deployed service"
       docker_image:
         type: string
-        required: true
+        required: false
         description: "Docker image name"
+      cluster:
+        type: string
+        required: false
+        description: "Cluster name; if this is given, only a short message with the status of that cluster will be sent"
+      status:
+        type: string
+        required: true
+        description: "Deployment status; 'running' if deployment is in progress, 'success' if all went well, anything else if an error occurred"
       channels:
         type: string
         required: false
         description: "Comma-delimited list of Slack channels ID where the notification should be posted"
         default: "C8VDK46Q4"
-      status:
-        type: string
-        required: true
-        description: "Deployment status; 'running' if deployment is in progress, 'success' if all went well, anything else if an error occurred"
       update_ts:
         type: string
         required: false
@@ -44,10 +48,12 @@ jobs:
       - uses: actions/github-script@v6
         id: template
         env:
+          INPUT_CLUSTER: ${{ inputs.cluster }}
           INPUT_STATUS: ${{ inputs.status }}
           INPUT_UPDATE_TS: ${{ inputs.update_ts }}
         with:
           script: |
+            const cluster = process.env.INPUT_CLUSTER;
             const deploy_status = process.env.INPUT_STATUS;
             const update_ts = process.env.INPUT_UPDATE_TS;
 
@@ -55,7 +61,7 @@ jobs:
             var icon = "";
 
             if (deploy_status == "running") {
-                header += "New ${{ inputs.service_name }} deploying... :crossed_fingers:";
+                header += "Deploying ${{ inputs.service_name }} to ${{ inputs.service_name }} :crossed_fingers:";
                 icon = ":loading-mac:";
             } else if (deploy_status == "success") {
                 header += "New ${{ inputs.service_name }} deployed :rocket:"
@@ -63,6 +69,20 @@ jobs:
             } else {
                 header += "${{ inputs.service_name }} deployment failed :boom:"
                 icon = ":x:";
+            }
+
+            if (cluster) {
+                return {
+                    blocks: [
+                        {
+                            type: "section",
+                            text: {
+                                type: "mrkdwn",
+                                text: "`${{ inputs.cluster }}` " + icon
+                            }
+                        }
+                    ]
+                };
             }
 
             return {

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -7,10 +7,6 @@ on:
         type: string
         required: false
         description: "Human-readable name of the deployed service"
-      docker_image:
-        type: string
-        required: false
-        description: "Docker image name"
       cluster:
         type: string
         required: false
@@ -101,13 +97,6 @@ jobs:
                         text: {
                             type: "mrkdwn",
                             text: "*Revision*\n${{ github.sha }}"
-                        }
-                    },
-                    {
-                        type: "section",
-                        text: {
-                            type: "mrkdwn",
-                            text: "*Docker image*\n${{ inputs.docker_image }}"
                         }
                     },
                     {

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -121,7 +121,7 @@ jobs:
                         type: "section",
                         text: {
                             type: "mrkdwn",
-                            text: "*Status*
+                            text: "*Status*"
                         }
                     }
                 ]


### PR DESCRIPTION
<img width="389" alt="image" src="https://user-images.githubusercontent.com/16576075/215059508-36488b2e-ee9c-4279-84ee-02584ecc47dd.png">

- Title and status messages update automatically to reflect the deployment progress
- SHA links to commit on GitHub
- Cluster names link to their respective Nomad dashboards