### PR TITLE
Bump google-github-actions/auth to v2 for docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Authenticate with Google Cloud
         id: auth
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.gar_service_account_key }}
 


### PR DESCRIPTION
`v0` is no longer maintained, see the warning: https://github.com/remerge/context2as/actions/runs/7088796671/job/19292832585#step:6:15