### PR TITLE
Add Docker build target option to workflow configuration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,11 @@ on:
         required: false
         description: "Docker build arguments"
 
+      target:
+        type: string
+        required: false
+        description: "Docker build target"
+
       os:
         description: "OS version to run the workflow on. If not provided, defaults to 'ubuntu-latest'"
         type: string
@@ -176,6 +181,7 @@ jobs:
             BUILD_ID=${{ github.run_id }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: ${{ inputs.target }}
           ssh: default
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DSP-427
This functionality is needed to distinguish between production and development stages in Dockerfiles.

For example, different build targets can be used to include different sets of dependencies, configurations, or build steps based on the target environment (production or development).