### PR TITLE
Don't delete source maps before frontend deploy

### DIFF
--- a/.github/workflows/static-website.yml
+++ b/.github/workflows/static-website.yml
@@ -180,13 +180,6 @@ jobs:
           ROLLBAR_ACCESS_TOKEN: ${{ secrets.rollbar-access-token }}
           ROLLBAR_USERNAME: ${{ github.actor }}
 
-      - name: delete source maps before uploading code
-        if: ${{ steps.glob.outputs.paths != '' }}
-        id: delete_sourcemaps_before_upload
-        run: |
-          rm ${{ steps.glob.outputs.paths }}
-        working-directory: ${{ inputs.working-directory }}/${{ inputs.upload-folder }}
-
       - uses: google-github-actions/auth@v2
         with:
           token_format: access_token


### PR DESCRIPTION
The source maps aren't working with rollbar for an unknown reason and I need to inspect exactly what's being created by the deploy workflow so I'm temporarily disabling the deletion of source maps