### PR TITLE
Add re-usable workflow to create Jira tickets for Dependabot PRs

### DIFF
--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -1,0 +1,106 @@
+---
+name: jira-issues-for-dependabot
+
+on:
+  workflow_call:
+    inputs:
+      pr-url:
+        type: string
+        required: true
+        description: "The URL of the pull request created by Dependabot"
+
+      issue-type:
+        type: string
+        required: true
+        default: "10272"
+        description: "The URL of the pull request created by Dependabot"
+
+      project-id:
+        type: string
+        required: true
+        default: "10105"
+        description: "The URL of the pull request created by Dependabot"
+
+      reporter-user-id:
+        type: string
+        required: true
+        default: "5da9eda38cc4310c2c0d2565"
+        description: "The user ID of the reporter for the Jira issue"
+
+      jira-transition-id:
+        type: string
+        required: true
+        default: "431"
+        description: "The ID of the Jira transition to move the issue to the Review Requested column"
+
+      jira-issue-summary:
+        type: string
+        required: true
+        default: "Review Dependabot PR"
+        description: "The summary of the Jira issue to be created"
+
+jobs:
+  create-jira-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load Jira API token from 1password
+        uses: 1password/load-secrets-action@v2
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op_service_account_token }}
+          JIRA_API_KEY: "op://secrets/api.jira_api_key/password"
+
+      - name: Create Jira issue for Dependabot PR
+        run: |
+          export CREATED_ISSUE_RESPONSE=$(curl --request POST \
+            --url 'https://remerge.atlassian.net/rest/api/3/issue' \
+            --user "hal@remerge.io:${{ env.JIRA_API_KEY }}" \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '{
+              "fields": {
+                "description": {
+                  "content": [
+                    {
+                      "content": [
+                        {
+                          "text": "Dependabot has opened a PR which needs reviewing: ${{ inputs.pr-url }}",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "paragraph"
+                    }
+                  ],
+                  "type": "doc",
+                  "version": 1
+                },
+                "issuetype": {
+                  "id": "${{ inputs.issue-type }}"
+                },
+                "labels": [
+                  "dependabot"
+                ],
+                "project": {
+                  "id": "${{ inputs.project-id }}"
+                },
+                "reporter": {
+                  "id": "${{ inputs.reporter-user-id }}"
+                },
+                "summary": "${{ inputs.jira-issue-summary }}"
+              }
+            }')
+          export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
+          echo "Created Jira issue: $CREATED_ISSUE_URL"
+          echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
+
+      - name: Move created issue to the Review Requested column
+        run: |
+          echo "Trying to transition issue $CREATED_ISSUE_URL"
+          curl --request POST \
+            --url "$CREATED_ISSUE_URL/transitions" \
+            --user hal@remerge.io:${{ env.JIRA_API_KEY }} \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '{"transition": {"id": "${{ inputs.jira-transition-id }}"}}'

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -65,44 +65,6 @@ jobs:
           REPORTER_USER_ID: ${{ inputs.reporter-user-id }}
           JIRA_ISSUE_SUMMARY: ${{ inputs.jira-issue-summary }}
         run: |
-          echo curl --request POST \
-            --url 'https://remerge.atlassian.net/rest/api/3/issue' \
-            --user "hal@remerge.io:$JIRA_API_KEY" \
-            --header 'Accept: application/json' \
-            --header 'Content-Type: application/json' \
-            --data "{
-              \"fields\": {
-                \"description\": {
-                  \"content\": [
-                    {
-                      \"content\": [
-                        {
-                          \"text\": \"Dependabot has opened a PR which needs reviewing: $PR_URL\",
-                          \"type\": \"text\"
-                        }
-                      ],
-                      \"type\": \"paragraph\"
-                    }
-                  ],
-                  \"type\": \"doc\",
-                  \"version\": 1
-                },
-                \"issuetype\": {
-                  \"id\": \"$ISSUE_TYPE\"
-                },
-                \"labels\": [
-                  \"dependabot\"
-                ],
-                \"project\": {
-                  \"id\": \"$PROJECT_ID\"
-                },
-                \"reporter\": {
-                  \"id\": \"$REPORTER_USER_ID\"
-                },
-                \"summary\": \"$JIRA_ISSUE_SUMMARY\"
-              }
-            }"
-
           export CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
             --user "hal@remerge.io:$JIRA_API_KEY" \
@@ -141,7 +103,6 @@ jobs:
               }
             }")
           export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
-          echo $CREATED_ISSUE_RESPONSE
           echo "Created Jira issue: $CREATED_ISSUE_URL"
           echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
 

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -12,12 +12,12 @@ on:
       issue-type:
         type: string
         default: "10272"
-        description: "The URL of the pull request created by Dependabot"
+        description: "The ID of a Jira issue type to create"
 
       project-id:
         type: string
         default: "10105"
-        description: "The URL of the pull request created by Dependabot"
+        description: "The ID of the project to create the issue in"
 
       reporter-user-id:
         type: string

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -11,31 +11,26 @@ on:
 
       issue-type:
         type: string
-        required: true
         default: "10272"
         description: "The URL of the pull request created by Dependabot"
 
       project-id:
         type: string
-        required: true
         default: "10105"
         description: "The URL of the pull request created by Dependabot"
 
       reporter-user-id:
         type: string
-        required: true
         default: "5da9eda38cc4310c2c0d2565"
         description: "The user ID of the reporter for the Jira issue"
 
       jira-transition-id:
         type: string
-        required: true
         default: "431"
         description: "The ID of the Jira transition to move the issue to the Review Requested column"
 
       jira-issue-summary:
         type: string
-        required: true
         default: "Review Dependabot PR"
         description: "The summary of the Jira issue to be created"
 

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           export CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
-            --user "hal@remerge.io:${{ env.JIRA_API_KEY }}" \
+            --user "hal@remerge.io:$JIRA_API_KEY" \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
             --data '{
@@ -100,7 +100,7 @@ jobs:
           echo "Trying to transition issue $CREATED_ISSUE_URL"
           curl --request POST \
             --url "$CREATED_ISSUE_URL/transitions" \
-            --user hal@remerge.io:${{ env.JIRA_API_KEY }} \
+            --user hal@remerge.io:$JIRA_API_KEY \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
             --data '{"transition": {"id": "${{ inputs.jira-transition-id }}"}}'

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -39,6 +39,11 @@ on:
         default: "Review Dependabot PR"
         description: "The summary of the Jira issue to be created"
 
+    secrets:
+      op_service_account_token:
+        required: true
+        description: "1Password service account token for loading secrets"
+
 jobs:
   create-jira-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -97,10 +97,9 @@ jobs:
                 \"summary\": \"$JIRA_ISSUE_SUMMARY\"
               }
             }")
-          CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
-
+          CREATED_ISSUE_URL=$(echo "$CREATED_ISSUE_RESPONSE" | jq -r .self)
           echo "Created Jira issue: $CREATED_ISSUE_URL"
-          echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
+          echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> "$GITHUB_ENV"
 
       - name: Move created issue to the Review Requested column
         env:
@@ -109,7 +108,7 @@ jobs:
           echo "Trying to transition issue $CREATED_ISSUE_URL"
           curl --request POST \
             --url "$CREATED_ISSUE_URL/transitions" \
-            --user hal@remerge.io:$JIRA_API_KEY \
-            --header 'Accept: application/json' \
-            --header 'Content-Type: application/json' \
+            --user "hal@remerge.io:$JIRA_API_KEY" \
+            --header "Accept: application/json" \
+            --header "Content-Type: application/json" \
             --data "{\"transition\": {\"id\": \"$JIRA_TRANSITION_ID\"}}"

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -50,7 +50,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op_service_account_token }}
-          JIRA_API_KEY: "op://secrets/api.jira_api_key/password"
+          JIRA_API_KEY: "op://secrets/github.dependabot_jira_api_key/password"
 
       - name: Create Jira issue for Dependabot PR
         env:

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -155,4 +155,4 @@ jobs:
             --user hal@remerge.io:$JIRA_API_KEY \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
-            --data "{\"transition\": {\"id\": \"$JIRA_TRANSITION_ID\"}}""
+            --data "{\"transition\": {\"id\": \"$JIRA_TRANSITION_ID\"}}"

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -103,6 +103,7 @@ jobs:
               }
             }')
           export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
+          echo $CREATED_ISSUE_RESPONSE
           echo "Created Jira issue: $CREATED_ISSUE_URL"
           echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
 

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -60,7 +60,7 @@ jobs:
           REPORTER_USER_ID: ${{ inputs.reporter-user-id }}
           JIRA_ISSUE_SUMMARY: ${{ inputs.jira-issue-summary }}
         run: |
-          export CREATED_ISSUE_RESPONSE=$(curl --request POST \
+          CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
             --user "hal@remerge.io:$JIRA_API_KEY" \
             --header 'Accept: application/json' \
@@ -97,7 +97,8 @@ jobs:
                 \"summary\": \"$JIRA_ISSUE_SUMMARY\"
               }
             }")
-          export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
+          CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
+
           echo "Created Jira issue: $CREATED_ISSUE_URL"
           echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
 

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -65,6 +65,43 @@ jobs:
           REPORTER_USER_ID: ${{ inputs.reporter-user-id }}
           JIRA_ISSUE_SUMMARY: ${{ inputs.jira-issue-summary }}
         run: |
+          echo curl --request POST \
+              --url 'https://remerge.atlassian.net/rest/api/3/issue' \
+              --user "hal@remerge.io:$JIRA_API_KEY" \
+              --header 'Accept: application/json' \
+              --header 'Content-Type: application/json' \
+              --data '{
+                "fields": {
+                  "description": {
+                    "content": [
+                      {
+                        "content": [
+                          {
+                            "text": "Dependabot has opened a PR which needs reviewing: $PR_URL",
+                            "type": "text"
+                          }
+                        ],
+                        "type": "paragraph"
+                      }
+                    ],
+                    "type": "doc",
+                    "version": 1
+                  },
+                  "issuetype": {
+                    "id": "$ISSUE_TYPE"
+                  },
+                  "labels": [
+                    "dependabot"
+                  ],
+                  "project": {
+                    "id": "$PROJECT_ID"
+                  },
+                  "reporter": {
+                    "id": "$REPORTER_USER_ID"
+                  },
+                  "summary": "$JIRA_ISSUE_SUMMARY"
+                }
+              }'
           export CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
             --user "hal@remerge.io:$JIRA_API_KEY" \

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -11,22 +11,22 @@ on:
 
       issue-type:
         type: string
-        default: "10272"
+        required: true
         description: "The ID of a Jira issue type to create"
 
       project-id:
         type: string
-        default: "10105"
+        required: true
         description: "The ID of the project to create the issue in"
 
       reporter-user-id:
         type: string
-        default: "5da9eda38cc4310c2c0d2565"
+        required: true
         description: "The user ID of the reporter for the Jira issue"
 
       jira-transition-id:
         type: string
-        default: "431"
+        required: true
         description: "The ID of the Jira transition to move the issue to the Review Requested column"
 
       jira-issue-summary:

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -66,79 +66,80 @@ jobs:
           JIRA_ISSUE_SUMMARY: ${{ inputs.jira-issue-summary }}
         run: |
           echo curl --request POST \
-              --url 'https://remerge.atlassian.net/rest/api/3/issue' \
-              --user "hal@remerge.io:$JIRA_API_KEY" \
-              --header 'Accept: application/json' \
-              --header 'Content-Type: application/json' \
-              --data '{
-                "fields": {
-                  "description": {
-                    "content": [
-                      {
-                        "content": [
-                          {
-                            "text": "Dependabot has opened a PR which needs reviewing: $PR_URL",
-                            "type": "text"
-                          }
-                        ],
-                        "type": "paragraph"
-                      }
-                    ],
-                    "type": "doc",
-                    "version": 1
-                  },
-                  "issuetype": {
-                    "id": "$ISSUE_TYPE"
-                  },
-                  "labels": [
-                    "dependabot"
+            --url 'https://remerge.atlassian.net/rest/api/3/issue' \
+            --user "hal@remerge.io:$JIRA_API_KEY" \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data "{
+              \"fields\": {
+                \"description\": {
+                  \"content\": [
+                    {
+                      \"content\": [
+                        {
+                          \"text\": \"Dependabot has opened a PR which needs reviewing: $PR_URL\",
+                          \"type\": \"text\"
+                        }
+                      ],
+                      \"type\": \"paragraph\"
+                    }
                   ],
-                  "project": {
-                    "id": "$PROJECT_ID"
-                  },
-                  "reporter": {
-                    "id": "$REPORTER_USER_ID"
-                  },
-                  "summary": "$JIRA_ISSUE_SUMMARY"
-                }
-              }'
+                  \"type\": \"doc\",
+                  \"version\": 1
+                },
+                \"issuetype\": {
+                  \"id\": \"$ISSUE_TYPE\"
+                },
+                \"labels\": [
+                  \"dependabot\"
+                ],
+                \"project\": {
+                  \"id\": \"$PROJECT_ID\"
+                },
+                \"reporter\": {
+                  \"id\": \"$REPORTER_USER_ID\"
+                },
+                \"summary\": \"$JIRA_ISSUE_SUMMARY\"
+              }
+            }"
+
           export CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
             --user "hal@remerge.io:$JIRA_API_KEY" \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
-            --data '{
-              "fields": {
-                "description": {
-                  "content": [
+            --data "{
+              \"fields\": {
+                \"description\": {
+                  \"content\": [
                     {
-                      "content": [
+                      \"content\": [
                         {
-                          "text": "Dependabot has opened a PR which needs reviewing: $PR_URL",
-                          "type": "text"
+                          \"text\": \"Dependabot has opened a PR which needs reviewing: $PR_URL\",
+                          \"type\": \"text\"
                         }
                       ],
-                      "type": "paragraph"
+                      \"type\": \"paragraph\"
                     }
                   ],
-                  "type": "doc",
-                  "version": 1
+                  \"type\": \"doc\",
+                  \"version\": 1
                 },
-                "issuetype": {
-                  "id": "$ISSUE_TYPE"
+                \"issuetype\": {
+                  \"id\": \"$ISSUE_TYPE\"
                 },
-                "labels": [
-                  "dependabot"
+                \"labels\": [
+                  \"dependabot\"
                 ],
-                "project": {
-                  "id": "$PROJECT_ID"
+                \"project\": {
+                  \"id\": \"$PROJECT_ID\"
                 },
-                "reporter": {
-                  "id": "$REPORTER_USER_ID"
+                \"reporter\": {
+                  \"id\": \"$REPORTER_USER_ID\"
                 },
-                "summary": "$JIRA_ISSUE_SUMMARY"
+                \"summary\": \"$JIRA_ISSUE_SUMMARY\"
               }
-            }')
+            }")
           export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
           echo $CREATED_ISSUE_RESPONSE
           echo "Created Jira issue: $CREATED_ISSUE_URL"
@@ -154,4 +155,4 @@ jobs:
             --user hal@remerge.io:$JIRA_API_KEY \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
-            --data '{"transition": {"id": "$JIRA_TRANSITION_ID"}}'
+            --data "{\"transition\": {\"id\": \"$JIRA_TRANSITION_ID\"}}""

--- a/.github/workflows/jira-tickets-for-dependabot.yml
+++ b/.github/workflows/jira-tickets-for-dependabot.yml
@@ -53,6 +53,12 @@ jobs:
           JIRA_API_KEY: "op://secrets/api.jira_api_key/password"
 
       - name: Create Jira issue for Dependabot PR
+        env:
+          PR_URL: ${{ inputs.pr-url }}
+          ISSUE_TYPE: ${{ inputs.issue-type }}
+          PROJECT_ID: ${{ inputs.project-id }}
+          REPORTER_USER_ID: ${{ inputs.reporter-user-id }}
+          JIRA_ISSUE_SUMMARY: ${{ inputs.jira-issue-summary }}
         run: |
           export CREATED_ISSUE_RESPONSE=$(curl --request POST \
             --url 'https://remerge.atlassian.net/rest/api/3/issue' \
@@ -66,7 +72,7 @@ jobs:
                     {
                       "content": [
                         {
-                          "text": "Dependabot has opened a PR which needs reviewing: ${{ inputs.pr-url }}",
+                          "text": "Dependabot has opened a PR which needs reviewing: $PR_URL",
                           "type": "text"
                         }
                       ],
@@ -77,18 +83,18 @@ jobs:
                   "version": 1
                 },
                 "issuetype": {
-                  "id": "${{ inputs.issue-type }}"
+                  "id": "$ISSUE_TYPE"
                 },
                 "labels": [
                   "dependabot"
                 ],
                 "project": {
-                  "id": "${{ inputs.project-id }}"
+                  "id": "$PROJECT_ID"
                 },
                 "reporter": {
-                  "id": "${{ inputs.reporter-user-id }}"
+                  "id": "$REPORTER_USER_ID"
                 },
-                "summary": "${{ inputs.jira-issue-summary }}"
+                "summary": "$JIRA_ISSUE_SUMMARY"
               }
             }')
           export CREATED_ISSUE_URL=$(echo $CREATED_ISSUE_RESPONSE | jq -r .self)
@@ -96,6 +102,8 @@ jobs:
           echo "CREATED_ISSUE_URL=$CREATED_ISSUE_URL" >> $GITHUB_ENV
 
       - name: Move created issue to the Review Requested column
+        env:
+          JIRA_TRANSITION_ID: ${{ inputs.jira-transition-id }}
         run: |
           echo "Trying to transition issue $CREATED_ISSUE_URL"
           curl --request POST \
@@ -103,4 +111,4 @@ jobs:
             --user hal@remerge.io:$JIRA_API_KEY \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \
-            --data '{"transition": {"id": "${{ inputs.jira-transition-id }}"}}'
+            --data '{"transition": {"id": "$JIRA_TRANSITION_ID"}}'


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DSP-1016
The workflow creates an issue then applies a given transition to it. The defaults put the issue on the DSP board in the Review Requested column

Example usage:

```yaml
jobs:
  jira-issues-for-dependabot:
    if: github.actor == 'dependabot[bot]'
    uses: remerge/workflows/.github/workflows/jira-tickets-for-dependabot.yml@DSP-1016
    with:
      pr-url: ${{ github.event.pull_request.html_url }}
      issue-type: "10272"
      project-id: "10105"
      reporter-user-id: "5da9eda38cc4310c2c0d2565"
      jira-transition-id: "431"
      jira-issue-summary: "Review Dependabot PR"
    secrets:
      op_service_account_token: ${{ secrets.op_service_account_token }}
```